### PR TITLE
Harden streamlit restart: kill stale listeners and verify port ownership

### DIFF
--- a/zdm-microservices/restart_streamlit.sh
+++ b/zdm-microservices/restart_streamlit.sh
@@ -75,6 +75,13 @@ if command -v ss >/dev/null 2>&1; then
     log "Port $PORT occupied by pid(s): $pids_on_port; killing..."
     kill $pids_on_port || true
     sleep 1
+    # double-check and force kill if still present
+    pids_on_port="$(ss -ltnp | awk -v p=":$PORT" '$4 ~ p {print $NF}' | sed -n 's/.*pid=\([0-9]\+\).*/\1/p' | sort -u)"
+    if [[ -n "$pids_on_port" ]]; then
+      log "Port $PORT still busy after kill; forcing kill -9: $pids_on_port"
+      kill -9 $pids_on_port || true
+      sleep 1
+    fi
   fi
 fi
 
@@ -96,6 +103,15 @@ sleep 2
 
 newpid="$(cat "$PIDFILE")"
 log "Started pid=$newpid"
+
+# Verify port is owned by new pid; else fail fast
+if command -v ss >/dev/null 2>&1; then
+  pids_on_port="$(ss -ltnp | awk -v p=":$PORT" '$4 ~ p {print $NF}' | sed -n 's/.*pid=\([0-9]\+\).*/\1/p' | sort -u)"
+  if ! echo "$pids_on_port" | grep -qw "$newpid"; then
+    log "ERROR: Port $PORT is not owned by new pid $newpid (pids on port: $pids_on_port)"
+    exit 1
+  fi
+fi
 
 log "Listening check:"
 if command -v ss >/dev/null 2>&1; then


### PR DESCRIPTION
Hardened the Streamlit restart script to prevent stale listeners:

If the port is still occupied after the initial kill, it now force-kills (kill -9) remaining pids and rechecks.

After starting Streamlit, it verifies that the new pid owns the port; if not, it exits with an error to avoid a silent hang.

This should prevent the “old pid still on port 8000” situation that caused the timeout. Use the script normally; it will now fail fast if it can’t take over the port.